### PR TITLE
Improve jcenter support with the plugin keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,10 @@ A gradle plugin for creating the .syntastic_javac_config file used by syntastic 
 
 ##### Using the Plugin
 ```
-buildscript {
-  repositories {
-    maven {
-      url "https://plugins.gradle.org/m2/"
-    }
-  }
-  dependencies {
-    classpath "com.scuilion.syntastic:gradle-syntastic-plugin:0.3.2"
-  }
+plugins {
+  id "com.scuilion.syntastic" version "0.3.3"
 }
-
-apply plugin: "com.scuilion.syntastic"
 ```
 
 Task
-* createSyntastic - for working in vim with the [syntastic](https://github.com/scrooloose/syntastic) syntastic checking plugin.
-
-This plugin attaches the createSyntastic plugin to 'compileJava' and 'compileGroovy' tasks. It must be applied after your configure you project.
+* syntastic - for working in vim with the [syntastic](https://github.com/scrooloose/syntastic) syntastic checking plugin.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.scuilion.syntastic
-version=0.3.2
+version=0.3.3
 artifactTags=utility syntastic
 pluginDescription=Integrate syntastic with your gradle projects.
 syntasticVcsUrl=https\://github.com/scuilion/gradle-syntastic-plugin.git

--- a/src/integrationTest/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticTest.groovy
+++ b/src/integrationTest/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticTest.groovy
@@ -25,7 +25,7 @@ class SyntasticTest {
             def build = connection.newBuild()
             build.setStandardOutput(output)
             build.setStandardError(error)
-            build.forTasks('createSyntastic')
+            build.forTasks('syntastic')
             build.run()
         } catch (Exception e) {
             def x = 'x' * 30

--- a/src/integrationTest/resources/pluginTest/syntasticTest/build.gradle
+++ b/src/integrationTest/resources/pluginTest/syntasticTest/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.scuilion.syntastic:gradle-syntastic-plugin:0.3.2"
+        classpath "com.scuilion.syntastic:gradle-syntastic-plugin:0.3.3"
     }
 }
 

--- a/src/main/groovy/com/scuilion/gradle/plugins/syntastic/Syntastic.groovy
+++ b/src/main/groovy/com/scuilion/gradle/plugins/syntastic/Syntastic.groovy
@@ -1,0 +1,38 @@
+package com.scuilion.gradle.plugins.syntastic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.SkipWhenEmpty
+import org.gradle.api.tasks.TaskAction
+
+class Syntastic extends DefaultTask {
+
+    private Closure resolver
+
+    @InputFiles
+    @SkipWhenEmpty
+    FileCollection getClasspath() {
+        resolver.call()
+    }
+
+    void setResolver(Closure closure) {
+        resolver = closure
+    }
+
+    @OutputFile
+    File output = new File('.syntastic_javac_config')
+
+    String getValue() {
+        classpath.files.join File.pathSeparator
+    }
+
+    @TaskAction
+    void generate() {
+        output.withWriter {
+            it.write "let g:syntastic_java_javac_classpath = \"${value}\"\n"
+        }
+    }
+
+}

--- a/src/main/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticPlugin.groovy
+++ b/src/main/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticPlugin.groovy
@@ -1,75 +1,34 @@
 package com.scuilion.gradle.plugins.syntastic
 
-import org.gradle.api.Project
 import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaBasePlugin
 
 class SyntasticPlugin implements Plugin<Project> {
 
-    private static final String GROUP = 'Syntastic'
-    private static final String DESCRIPTION = 'A plugin integration for Syntastic'
-    private static final String SYNTASTIC_TASK_NAME = 'createSyntastic'
+    static final TASK_NAME = 'syntastic'
 
     void apply(Project project) {
-        addTask(project)
-    }
+        def task = project.tasks.create(TASK_NAME, Syntastic)
 
-    private static void addTask(Project project) {
-        project.task(SYNTASTIC_TASK_NAME) {
-            def classpathFiles = [] as Set
-            def addJars = { proj ->
-                addJarDeps(proj, classpathFiles)
-                addSrcDirs(proj, classpathFiles)
-            }
+        task.with {
+            group = 'vim'
+            description = 'Generate Syntastic Java configuration'
 
-            project.childProjects.each { proj ->
-                addJars(proj.value)
-            }
-            addJars(project.rootProject)
-            def outputFile = project.file(project.rootProject.projectDir.absolutePath + "/.syntastic_javac_config")
-            inputs.property "classpath", getClassPathListed(classpathFiles)
-            outputs.file outputFile
-            doLast {
-                outputFile.write ''
-                outputFile.write inputs.properties.classpath
-            }
-        }
+            resolver { // lazy evaluation
+                def cp = project.files()
 
-        attachTo(project, 'compileJava')
-        attachTo(project, 'compileGroovy')
-        project.tasks.createSyntastic.group = GROUP
-        project.tasks.createSyntastic.description = DESCRIPTION
-    }
-
-    static private void attachTo(Project project, String lang) {
-        if (project.tasks.findByName(lang)) {
-            project.tasks.getByName(lang).dependsOn(SYNTASTIC_TASK_NAME)
-        }
-    }
-
-    static private String getClassPathListed(def classpathFiles) {
-        //def classpathList = getUnifiedPath(classpathFiles)  assume the path separator is correct.
-        return 'let g:syntastic_java_javac_classpath = "' + classpathFiles.join(joinCharacter) + '"'
-    }
-
-    static private String getJoinCharacter() {
-        return File.pathSeparator
-    }
-
-    static private void addSrcDirs(project, classpathFiles) {
-        if (project.hasProperty('sourceSets')) {
-            project.sourceSets.each { srcSet ->
-                srcSet.java.srcDirs.each { dir ->
-                    classpathFiles.add(new File(dir.absolutePath))
+                project.plugins.withType(JavaBasePlugin) {
+                    project?.sourceSets.all {
+                        cp += it.output + it.compileClasspath
+                    }
                 }
+
+                cp
             }
         }
+
+        project.tasks.findByPath(':build')?.dependsOn TASK_NAME
     }
 
-    static private void addJarDeps(Project project, Set<String> classpathFiles) {
-        project.configurations.each { conf ->
-            conf.each { jar ->
-                classpathFiles.add(jar)
-            }
-        }
-    }
 }

--- a/src/test/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticPluginTest.groovy
+++ b/src/test/groovy/com/scuilion/gradle/plugins/syntastic/SyntasticPluginTest.groovy
@@ -1,0 +1,134 @@
+package com.scuilion.gradle.plugins.syntastic
+
+import static org.junit.Assume.assumeFalse
+import static org.junit.Assume.assumeTrue
+
+import org.apache.commons.lang3.SystemUtils
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test
+
+class SyntasticPluginTest {
+
+    private Project project
+
+    @Before
+    void setupProject() {
+        project = ProjectBuilder.builder().build()
+    }
+
+    private Syntastic extractTask() {
+        def task = project.tasks.syntastic
+        assert task instanceof Syntastic
+        assert task.output != null
+        assert task.classpath != null
+        task
+    }
+
+    @Test
+    void nothingToDo() {
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = extractTask()
+        assert task.classpath.files.empty
+    }
+
+    @Test
+    void javaProject() {
+        project.pluginManager.apply 'java'
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = extractTask()
+        assert !task.classpath.files.empty
+    }
+
+    @Test
+    void groovyProject() {
+        project.pluginManager.apply 'groovy'
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = extractTask()
+        assert !task.classpath.files.empty
+    }
+
+    @Test
+    void windowsSinglePath() {
+        assumeTrue SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('a')
+        }
+        assert !task.value.contains('/')
+        assert !task.value.contains(';')
+    }
+
+    @Test
+    void nixSinglePath() {
+        assumeFalse SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('a')
+        }
+        assert !task.value.contains('\\')
+        assert !task.value.contains(';')
+    }
+
+    @Test
+    void windowsSeveralPaths() {
+        assumeTrue SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('a', 'b', 'c')
+        }
+        assert !task.value.contains('/')
+        assert  task.value.chars.findAll { "$it" == ";" }.size == 2
+    }
+
+    @Test
+    void nixSeveralPaths() {
+        assumeFalse SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('a', 'b', 'c')
+        }
+        assert !task.value.contains('\\')
+        assert !task.value.contains(';')
+        assert  task.value.chars.findAll { "$it" == ":" }.size == 2
+    }
+
+    @Test
+    void windowsDeduplicatePaths() {
+        assumeTrue SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('A', 'C', 'D', 'C')
+        }
+        assert !task.value.contains('/')
+        assert  task.value.chars.findAll { "$it" == ";" }.size == 2
+    }
+
+    @Test
+    void nixDeduplicatePaths() {
+        assumeFalse SystemUtils.IS_OS_WINDOWS
+        project.pluginManager.apply 'com.scuilion.syntastic'
+
+        def task = project.tasks.syntastic
+        task.resolver {
+            project.files('A', 'C', 'D', 'C')
+        }
+        assert !task.value.contains('\\')
+        assert !task.value.contains(';')
+        assert  task.value.chars.findAll { "$it" == ":" }.size == 2
+    }
+}


### PR DESCRIPTION
Thanks again for making it possible to enjoy java coding in vim.

One thing that was bothering me though, is that I couldn't use it in a plugin block. After some digging in groovy and gradle (I have little experience with both) I have finally managed to make it possible, I suppose.

I work on Linux, so **I can't test it on Windows**, and it turned out (on my machine) that integration tests don't run. I have broken them intentionally, but it didn't fail the build.

I have successfully tested it on a project using your plugin, and I am now able to do this:
```groovy
plugins {
        id "org.gradle.java"
        id "org.gradle.jacoco"
        id "org.gradle.pmd"
        id "org.gradle.findbugs"
}

// added to the project by linking buildSrc/src to gradle-syntastic-plugin/src
apply plugin: 'com.scuilion.syntastic'

[...]
```

So I assume that a new release with this fix would allow me to turn the `apply` statement into a `plugins id`. I can't know for sure...

Of course this fix breaks integration tests, I will push more commits depending on your feedback :)